### PR TITLE
Atualiza navegação do fluxo de abertura de turno

### DIFF
--- a/lib/core/core_app/controllers/turno_controller.dart
+++ b/lib/core/core_app/controllers/turno_controller.dart
@@ -258,7 +258,9 @@ class TurnoController extends GetxController {
       // Vai para tela de abertura de turno
       AppLogger.d('Navegando para tela de abertura de turno',
           tag: 'TurnoController');
-      Get.toNamed('/abrir-turno');
+      // Utiliza a rota nomeada centralizada para manter consistência e
+      // facilitar futuras alterações de caminho sem afetar chamadas diretas.
+      Get.toNamed(Routes.turnoAbrir);
     } else {
       // Vai para a rota específica
       AppLogger.d('Navegando para: $rota', tag: 'TurnoController');


### PR DESCRIPTION
## Summary
- substituir a navegação direta por string para utilizar a rota nomeada centralizada ao direcionar o usuário para a tela de abertura de turno
- documentar a escolha da rota nomeada para facilitar manutenções futuras no fluxo de abertura de turno

## Testing
- not run (manual testing required)

------
https://chatgpt.com/codex/tasks/task_e_68e2c44546f88327a13698be821f16d2