### PR TITLE
Optimize checklist option caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # nexa_app
 
 A new Flutter project.
+
+## Notas de manutenção recentes
+
+- 2025-10-05: O serviço de checklist passou a reutilizar em memória as opções
+  de resposta buscadas por modelo, evitando consultas repetidas ao banco durante
+  a montagem das perguntas. Essa estratégia mantém a compatibilidade com futuros
+  cenários onde cada pergunta possua subconjuntos específicos, pois o cache é
+  distribuído via mapa antes do loop principal.


### PR DESCRIPTION
## Summary
- cache checklist option queries per checklist model and reuse them across questions
- add inline logging and documentation explaining the new caching strategy
- update the README with maintenance notes about the checklist service change

## Testing
- not run (environment missing Dart/Flutter tooling)

------
https://chatgpt.com/codex/tasks/task_e_68e2c45087f08327bafc94387dfe20dd