### PR TITLE
docs: document architecture and reuse abrir turno data caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,160 @@
-# nexa_app
+# Nexa App
 
-## Checklist Service – Guia rápido
+Aplicativo Flutter organizado em módulos orientados a fluxo, com gerenciamento
+reativo de estado via GetX e persistência local através do Drift. Este guia
+resume as principais decisões arquiteturais, responsabilidades por camada e
+boas práticas adotadas para manter o código reutilizável e sustentável.
 
-O módulo de checklist foi atualizado para utilizar injeção de dependências via
-construtor (`ChecklistService`). Isso permite substituir os repositórios por
-fakes em testes e torna explícitas as camadas acessadas para montar o
-checklist.
+## Sumário
 
-### Dependências injetadas
+- [Visão Geral da Arquitetura](#visão-geral-da-arquitetura)
+  - [Camadas principais](#camadas-principais)
+  - [Fluxo de dados](#fluxo-de-dados)
+- [Estrutura de Pastas](#estrutura-de-pastas)
+  - [Core](#core)
+  - [Modules](#modules)
+  - [Widgets Compartilhados](#widgets-compartilhados)
+- [Serviços e Padrões de Reuso](#serviços-e-padrões-de-reuso)
+  - [Abrir Turno](#abrir-turno)
+  - [Checklist](#checklist)
+- [Banco de Dados e Sincronização](#banco-de-dados-e-sincronização)
+- [Orientações para Novos Módulos](#orientações-para-novos-módulos)
+- [Boas Práticas Gerais](#boas-práticas-gerais)
+- [Testes e Qualidade](#testes-e-qualidade)
 
-O serviço agora recebe os seguintes repositórios (registrados via `Get.find`):
+## Visão Geral da Arquitetura
 
-- `ChecklistModeloRepo`
-- `ChecklistPerguntaRepo`
-- `ChecklistOpcaoRespostaRepo`
-- `TurnoRepo`
-- `VeiculoRepo`
+### Camadas principais
 
-### Fluxo interno
+| Camada  | Responsabilidade                                                                 |
+|---------|-----------------------------------------------------------------------------------|
+| **UI**  | Widgets, páginas e controllers GetX focados em interação e estado da tela.       |
+| **Services** | Orquestra lógica de negócio utilizando repositórios e coordenando controllers. |
+| **Domain/Repositories** | Exposição de operações de dados (Drift + Dio) via contratos fortemente tipados. |
+| **Infra** | Implementações de banco (`core/database`) e cliente HTTP (`core/utils/network`). |
 
-1. Buscar modelos pelo tipo de veículo através do `ChecklistModeloRepo`.
-2. Validar a existência do `remoteId` e registrar logs diagnósticos.
-3. Consultar perguntas e opções relacionadas ao modelo pelos respectivos
-   repositórios.
-4. Montar `ChecklistCompletoModel` com as perguntas e opções convertidas.
-5. (Para o fluxo do turno ativo) consultar o turno vigente e o veículo
-   associado antes de delegar para `buscarChecklistPorTipoVeiculo`.
+### Fluxo de dados
 
-### Testes
+1. A UI interage com **controllers** GetX (por exemplo `AbrirTurnoController`).
+2. Controllers delegam lógica pesada para **services** (`AbrirTurnoService`,
+   `ChecklistService`), que concentram orquestrações.
+3. Services consomem **repositórios de domínio**, responsáveis por consultar o
+   banco local (Drift) ou APIs via Dio.
+4. Models de domínio são repassados à UI para renderização, mantendo as páginas
+   desacopladas de detalhes de infraestrutura.
 
-Foram adicionados testes unitários em
-`test/modules/turno/checklist/checklist_service_test.dart`, com fakes que
-simulam os repositórios. Execute-os com:
+## Estrutura de Pastas
 
-```bash
-flutter test
+```
+lib/
+├── core/
+│   ├── core_app/        # Bindings, controllers e serviços globais
+│   ├── database/        # Definições do Drift e DAOs
+│   ├── domain/          # DTOs, models e repositórios
+│   ├── middlewares/     # Middlewares GetX
+│   ├── sync/            # Serviços auxiliares de sincronização
+│   └── utils/           # Helpers, loggers, formatadores
+├── modules/
+│   └── turno/           # Fluxos específicos do domínio de turnos
+│       ├── abrir/       # Abertura de turno (UI + Service + Validators)
+│       └── checklist/   # Checklist do turno ativo
+├── routes/              # Definição central das rotas
+└── widgets/             # Componentes reutilizáveis (ex.: dropdown pesquisável)
 ```
 
-> **Observação:** caso o SDK do Flutter não esteja disponível no ambiente,
-> utilize o script como referência para um fluxo manual de validação. Ele
-> demonstra claramente como configurar os fakes e quais cenários são cobertos.
+### Core
+
+- **`core_app/bindings/initial_binding.dart`** registra dependências globais
+  (Drift, Dio, repositórios compartilhados, `TurnoController`, etc.).
+- **`core_app/controllers/`** concentra controladores acessíveis em todo o app.
+- **`domain/`** define DTOs para persistência, models de domínio usados na UI e
+  repositórios que encapsulam regras de acesso a dados.
+
+### Modules
+
+Cada módulo agrupa binding, controller, service, páginas e validadores de um
+fluxo específico. O módulo `turno` possui submódulos:
+
+- `abrir/`: fluxo de abertura de turno, com service especializado e validators.
+- `checklist/`: montagem e exibição do checklist vinculado ao turno ativo.
+
+### Widgets Compartilhados
+
+Componentes genéricos ficam em `lib/widgets/`. O
+`SearchableDropdownController` abstrai listas pesquisáveis com debounce e
+suporte a consulta remota.
+
+## Serviços e Padrões de Reuso
+
+### Abrir Turno
+
+O `AbrirTurnoService` recebeu injeção de dependências por construtor e um cache
+em memória para evitar requisições duplicadas ao digitar nos dropdowns. O
+service expõe métodos tipados e um value object (`AbrirTurnoDados`) que agrupa
+veículos, equipes e eletricistas:
+
+- `buscarVeiculos/Eletricistas/Equipes({forceRefresh})`: reaproveita a última
+  consulta quando possível.
+- `buscarDadosIniciais()`: retorna um pacote completo pronto para alimentar a
+  UI, garantindo consistência entre listas.
+- `limparCache()`: permite invalidar o cache em cenários de sincronização ou
+  troca de usuário.
+
+O `AbrirTurnoController` consome esse pacote e mantém um cache local para os
+métodos de busca do dropdown, reduzindo acoplamento entre UI e serviço e
+reforçando a reutilização de dados.
+
+### Checklist
+
+O `ChecklistService` continua responsável por montar checklists completos a
+partir de repositórios de modelo, perguntas e opções. A lógica de montagem está
+isolada do restante da aplicação, permitindo testes unitários com fakes e
+facilitando a substituição dos repositórios no futuro.
+
+## Banco de Dados e Sincronização
+
+- O projeto utiliza **Drift** como camada de persistência. Os DTOs em
+  `core/domain/dto` refletem as tabelas e são usados pelos repositórios.
+- Repositórios implementam contratos de sincronização (`SyncableRepository`),
+  viabilizando fluxos offline-first.
+- O `SyncService` coordena sincronizações e pode ser extendido para consumir os
+  caches expostos pelos services.
+
+## Orientações para Novos Módulos
+
+1. **Crie uma pasta em `lib/modules/<feature>`** com subpastas para `binding`,
+   `controller`, `service`, `pages` e `validators`.
+2. **Registre dependências no binding** usando injeção por construtor para
+   facilitar testes.
+3. **Mantenha controllers enxutos**, delegando lógica para services ou use-cases.
+4. **Defina models/DTOs dedicados** caso seja necessário transitar dados entre
+   camadas (sem usar mapas dinâmicos).
+5. **Atualize as rotas** em `lib/routes/routes.dart` e utilize as constantes em
+   toda a navegação.
+6. **Documente o módulo** adicionando comentários de propósito e fluxos
+   principais nos arquivos alterados.
+
+## Boas Práticas Gerais
+
+- Prefira **injeção por construtor** em services para viabilizar testes.
+- Utilize **logs do `AppLogger`** para rastrear fluxos críticos e diagnósticos.
+- Evite acoplamento da UI com DTOs crus; converta-os em models amigáveis quando
+  necessário.
+- Centralize validações em classes utilitárias (ex.: `TurnoValidator`).
+- Reaproveite componentes reativos (`SearchableDropdownController`) para manter
+  consistência na UX.
+
+## Testes e Qualidade
+
+- Utilize `flutter analyze` para garantir que o código segue as regras do
+  projeto.
+- Tests unitários podem ser adicionados em `test/`, seguindo o padrão usado
+  para `ChecklistService`.
+- Para validar fluxos manuais:
+  1. Abra o app e autentique.
+  2. No módulo de turno, confirme se os dropdowns carregam com agilidade graças
+     ao cache do `AbrirTurnoService`.
+  3. Abra um turno e verifique a navegação para o checklist.
+
+> Em ambientes sem o SDK do Flutter instalado, foque em revisão estática e nos
+> logs emitidos pelas camadas de serviço.

--- a/lib/modules/turno/abrir/abrir_turno_binding.dart
+++ b/lib/modules/turno/abrir/abrir_turno_binding.dart
@@ -12,11 +12,18 @@ class AbrirTurnoBinding extends Bindings {
   @override
   void dependencies() {
 
-    Get.lazyPut(() => VeiculoRepo(dio: Get.find(), db: Get.find()));
-    Get.lazyPut(() => EletricistaRepo(dio: Get.find(), db: Get.find()));
-    Get.lazyPut(() => EquipeRepo(dio: Get.find(), db: Get.find()));
+    Get.lazyPut(() => EletricistaRepo(dio: Get.find(), db: Get.find()),
+        fenix: true);
+    Get.lazyPut(() => EquipeRepo(dio: Get.find(), db: Get.find()),
+        fenix: true);
 
-    Get.lazyPut(() => AbrirTurnoService());
+    Get.lazyPut(
+      () => AbrirTurnoService(
+        veiculoRepo: Get.find<VeiculoRepo>(),
+        eletricistaRepo: Get.find<EletricistaRepo>(),
+        equipeRepo: Get.find<EquipeRepo>(),
+      ),
+    );
     Get.lazyPut(() => AbrirTurnoController());
   }
 }

--- a/lib/modules/turno/abrir/models/abrir_turno_dados.dart
+++ b/lib/modules/turno/abrir/models/abrir_turno_dados.dart
@@ -1,0 +1,41 @@
+import 'package:nexa_app/core/domain/dto/eletricista_table_dto.dart';
+import 'package:nexa_app/core/domain/dto/equipe_table_dto.dart';
+import 'package:nexa_app/core/domain/dto/veiculo_table_dto.dart';
+
+/// Value object que concentra todos os dados necessários para abrir um turno.
+///
+/// O objetivo desta classe é evitar que camadas superiores manipulem mapas
+/// dinâmicos sem tipo, facilitando a reutilização do pacote de dados carregado
+/// pelo [AbrirTurnoService] e deixando explícitas as dependências de UI.
+class AbrirTurnoDados {
+  /// Conjunto de veículos disponíveis para seleção.
+  final List<VeiculoTableDto> veiculos;
+
+  /// Conjunto de eletricistas elegíveis para o turno.
+  final List<EletricistaTableDto> eletricistas;
+
+  /// Conjunto de equipes disponíveis.
+  final List<EquipeTableDto> equipes;
+
+  /// Cria um contêiner imutável com os dados necessários para abertura de turno.
+  const AbrirTurnoDados({
+    required this.veiculos,
+    required this.eletricistas,
+    required this.equipes,
+  });
+
+  /// Retorna uma nova instância com alguma das coleções atualizada.
+  ///
+  /// Mantemos cópias imutáveis para evitar efeitos colaterais entre camadas.
+  AbrirTurnoDados copyWith({
+    List<VeiculoTableDto>? veiculos,
+    List<EletricistaTableDto>? eletricistas,
+    List<EquipeTableDto>? equipes,
+  }) {
+    return AbrirTurnoDados(
+      veiculos: veiculos ?? this.veiculos,
+      eletricistas: eletricistas ?? this.eletricistas,
+      equipes: equipes ?? this.equipes,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor AbrirTurnoService to inject dependencies via constructor, add in-memory caching, and expose a typed data package for the abertura flow
- update AbrirTurnoController and binding to reuse cached lists when filtering dropdowns and reduce duplicate fetches
- document the architecture, module layout, and service responsibilities in the project README

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2c2a415b083279773a3263459f377